### PR TITLE
fix: ignore eslint in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/" 
+    directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "eslint"


### PR DESCRIPTION
Eslint is currently known to cause issues with intelijs IDE's when interacting with the code base. 

To prevent dependabot from attempting to update this dependency
* add eslint to dependabot ignore list